### PR TITLE
Adds function for token lifecycle management

### DIFF
--- a/test/msg/auth_test.exs
+++ b/test/msg/auth_test.exs
@@ -91,4 +91,11 @@ defmodule Msg.AuthTest do
       assert function_exported?(Msg.Auth, :refresh_access_token, 2)
     end
   end
+
+  describe "get_app_token/1" do
+    test "returns expected response shape" do
+      # Verify function signature
+      assert function_exported?(Msg.Auth, :get_app_token, 1)
+    end
+  end
 end

--- a/test/msg/integration/auth_test.exs
+++ b/test/msg/integration/auth_test.exs
@@ -190,4 +190,26 @@ defmodule Msg.Integration.AuthTest do
       assert String.contains?(tokens.scope, "Calendars.ReadWrite")
     end
   end
+
+  describe "get_app_token/1" do
+    test "returns access token with metadata", %{credentials: credentials} do
+      {:ok, token_info} = Auth.get_app_token(credentials)
+
+      assert is_binary(token_info.access_token)
+      assert token_info.token_type == "Bearer"
+      assert is_integer(token_info.expires_in)
+      assert token_info.expires_in > 0
+    end
+
+    test "returns error for invalid credentials" do
+      invalid_creds = %{
+        client_id: "invalid-id",
+        client_secret: "invalid-secret",
+        tenant_id: "invalid-tenant"
+      }
+
+      assert {:error, %{status: status}} = Auth.get_app_token(invalid_creds)
+      assert status == 400
+    end
+  end
 end


### PR DESCRIPTION
Implements get_app_token/1 to obtain application-only access tokens with metadata suitable for TokenManager implementations. Unlike Client.fetch_token!/1 which returns just the token string, this function returns {:ok, metadata} with access_token, expires_in, and token_type for accurate token expiration tracking.

This enables TokenManager in MatMan to:
- Track token expiry accurately using expires_in
- Handle errors gracefully with {:ok, _} | {:error, _} pattern
- Store tokens with computed expiration timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)